### PR TITLE
Replace deprecated usage of logical `indicators` with `"none"`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 Imports: 
-    hardhat,
+    hardhat (>= 0.1.4),
     butcher,
     rpart,
     C50,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # baguette (development version)
 
+* Updated internal usage of a soft-deprecated argument to `hardhat::default_formula_blueprint()`.
+
 # baguette 0.1.0
 
 * Added encoding information to work with current version of `parsnip`. 

--- a/R/bagger.R
+++ b/R/bagger.R
@@ -176,7 +176,7 @@ bagger.formula <-
 
     validate_args(base_model, times, control, cost)
 
-    bp <- hardhat::default_formula_blueprint(indicators = FALSE)
+    bp <- hardhat::default_formula_blueprint(indicators = "none")
     processed <- hardhat::mold(formula, data, blueprint = bp)
     res <-
       bagger_bridge(processed,


### PR DESCRIPTION
Found when running revdeps on https://github.com/tidymodels/hardhat/pull/163