### PR TITLE
"noSuggests" R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: check-no-suggests.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -11,7 +11,7 @@ on:
     branches: [main, master]
   pull_request:
 
-name: check-no-suggests.yaml
+name: R-CMD-check-hard.yaml
 
 permissions: read-all
 

--- a/R/bagger.R
+++ b/R/bagger.R
@@ -44,49 +44,50 @@
 #' comparison of methods to study the contribution of variables in artificial
 #' neural network models. Ecological Modelling, 160(3), 249-264.
 #' @examples
-#' library(recipes)
-#' library(dplyr)
+#' if (rlang::is_installed(c("recipes", "modeldata"))) {
+#'   library(recipes)
+#'   library(dplyr)
 #'
-#' data(biomass, package = "modeldata")
+#'   data(biomass, package = "modeldata")
 #'
-#' biomass_tr <-
-#'   biomass %>%
-#'   dplyr::filter(dataset == "Training") %>%
-#'   dplyr::select(-dataset, -sample)
+#'   biomass_tr <-
+#'     biomass %>%
+#'     dplyr::filter(dataset == "Training") %>%
+#'     dplyr::select(-dataset, -sample)
 #'
-#' biomass_te <-
-#'   biomass %>%
-#'   dplyr::filter(dataset == "Testing") %>%
-#'   dplyr::select(-dataset, -sample)
+#'   biomass_te <-
+#'     biomass %>%
+#'     dplyr::filter(dataset == "Testing") %>%
+#'     dplyr::select(-dataset, -sample)
 #'
-#' # ------------------------------------------------------------------------------
+#'   # ------------------------------------------------------------------------------
 #'
-#' ctrl <- control_bag(var_imp = TRUE)
+#'   ctrl <- control_bag(var_imp = TRUE)
 #'
-#' # ------------------------------------------------------------------------------
+#'   # ------------------------------------------------------------------------------
 #'
-#' # `times` is low to make the examples run faster
+#'   # `times` is low to make the examples run faster
 #'
 #'
-#' set.seed(7687)
-#' cart_bag <- bagger(x = biomass_tr[, -6], y = biomass_tr$HHV,
-#'                    base_model = "CART", times = 5, control = ctrl)
-#' cart_bag
+#'   set.seed(7687)
+#'   cart_bag <- bagger(x = biomass_tr[, -6], y = biomass_tr$HHV,
+#'                      base_model = "CART", times = 5, control = ctrl)
+#'   cart_bag
 #'
-#' # ------------------------------------------------------------------------------
-#' # Other interfaces
+#'   # ------------------------------------------------------------------------------
+#'   # Other interfaces
 #'
-#' # Recipes can be used
-#' biomass_rec <-
-#'   recipe(HHV ~ ., data = biomass_tr) %>%
-#'   step_pca(all_predictors())
+#'   # Recipes can be used
+#'   biomass_rec <-
+#'     recipe(HHV ~ ., data = biomass_tr) %>%
+#'     step_pca(all_predictors())
 #'
-#' set.seed(7687)
-#' cart_pca_bag <- bagger(biomass_rec, data = biomass_tr, base_model = "CART",
-#'                        times = 5, control = ctrl)
+#'   set.seed(7687)
+#'   cart_pca_bag <- bagger(biomass_rec, data = biomass_tr, base_model = "CART",
+#'                          times = 5, control = ctrl)
 #'
-#' cart_pca_bag
-#'
+#'   cart_pca_bag
+#' }
 #' @export
 bagger <- function(x, ...) {
   UseMethod("bagger")

--- a/man/bagger.Rd
+++ b/man/bagger.Rd
@@ -110,49 +110,50 @@ For neural networks, variable importance is calculated using the method
 of Garson described in Gevrey \emph{et al} (2003)
 }
 \examples{
-library(recipes)
-library(dplyr)
+if (rlang::is_installed(c("recipes", "modeldata"))) {
+  library(recipes)
+  library(dplyr)
 
-data(biomass, package = "modeldata")
+  data(biomass, package = "modeldata")
 
-biomass_tr <-
-  biomass \%>\%
-  dplyr::filter(dataset == "Training") \%>\%
-  dplyr::select(-dataset, -sample)
+  biomass_tr <-
+    biomass \%>\%
+    dplyr::filter(dataset == "Training") \%>\%
+    dplyr::select(-dataset, -sample)
 
-biomass_te <-
-  biomass \%>\%
-  dplyr::filter(dataset == "Testing") \%>\%
-  dplyr::select(-dataset, -sample)
+  biomass_te <-
+    biomass \%>\%
+    dplyr::filter(dataset == "Testing") \%>\%
+    dplyr::select(-dataset, -sample)
 
-# ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
 
-ctrl <- control_bag(var_imp = TRUE)
+  ctrl <- control_bag(var_imp = TRUE)
 
-# ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
 
-# `times` is low to make the examples run faster
+  # `times` is low to make the examples run faster
 
 
-set.seed(7687)
-cart_bag <- bagger(x = biomass_tr[, -6], y = biomass_tr$HHV,
-                   base_model = "CART", times = 5, control = ctrl)
-cart_bag
+  set.seed(7687)
+  cart_bag <- bagger(x = biomass_tr[, -6], y = biomass_tr$HHV,
+                     base_model = "CART", times = 5, control = ctrl)
+  cart_bag
 
-# ------------------------------------------------------------------------------
-# Other interfaces
+  # ------------------------------------------------------------------------------
+  # Other interfaces
 
-# Recipes can be used
-biomass_rec <-
-  recipe(HHV ~ ., data = biomass_tr) \%>\%
-  step_pca(all_predictors())
+  # Recipes can be used
+  biomass_rec <-
+    recipe(HHV ~ ., data = biomass_tr) \%>\%
+    step_pca(all_predictors())
 
-set.seed(7687)
-cart_pca_bag <- bagger(biomass_rec, data = biomass_tr, base_model = "CART",
-                       times = 5, control = ctrl)
+  set.seed(7687)
+  cart_pca_bag <- bagger(biomass_rec, data = biomass_tr, base_model = "CART",
+                         times = 5, control = ctrl)
 
-cart_pca_bag
-
+  cart_pca_bag
+}
 }
 \references{
 Gevrey, M., Dimopoulos, I., and Lek, S. (2003). Review and

--- a/tests/testthat/helper-baguette.R
+++ b/tests/testthat/helper-baguette.R
@@ -1,9 +1,14 @@
 library(rlang)
 library(purrr)
-library(yardstick)
-library(recipes)
-
-data("two_class_dat", package = "modeldata")
+if (is_installed("yardstick")) {
+  library(yardstick)
+}
+if (is_installed("recipes")) {
+  library(recipes)
+}
+if (is_installed("modeldata")) {
+  data("two_class_dat", package = "modeldata")
+}
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test-C5.R
+++ b/tests/testthat/test-C5.R
@@ -66,6 +66,7 @@ test_that('check model reduction', {
 # ------------------------------------------------------------------------------
 
 test_that('check C5 parsnip interface', {
+  skip_if_not_installed("modeldata")
 
   set.seed(4779)
   expect_error(

--- a/tests/testthat/test-cart.R
+++ b/tests/testthat/test-cart.R
@@ -1,4 +1,5 @@
 test_that('check CART opt', {
+  skip_if_not_installed("modeldata")
 
   mod_1 <-
     bagger(

--- a/tests/testthat/test-cart.R
+++ b/tests/testthat/test-cart.R
@@ -99,6 +99,8 @@ test_that('check model reduction', {
 # ------------------------------------------------------------------------------
 
 test_that('check CART parsnip interface', {
+  skip_if_not_installed("modeldata")
+
   set.seed(4779)
   expect_error(
     reg_mod <- bag_tree(cost_complexity = .001, min_n = 3) %>%
@@ -204,6 +206,7 @@ test_that('mode specific package dependencies', {
 
 test_that('case weights', {
   skip_if_not_installed("modeldata")
+
   data("two_class_dat", package = "modeldata")
   set.seed(1)
   wts <- runif(nrow(two_class_dat))

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -1,4 +1,6 @@
 test_that('recipe execution', {
+  skip_if_not_installed("recipes")
+
   # check to make sure that prepped data are given to model
   rec <-
     recipe(Sepal.Length ~ ., data = iris) %>%

--- a/tests/testthat/test-mars.R
+++ b/tests/testthat/test-mars.R
@@ -1,5 +1,7 @@
 test_that('check mars opt', {
   skip_if_not_installed("earth")
+  skip_if_not_installed("modeldata")
+
   set.seed(36323)
   check_pruning <- function(x, ...) {
     rlang::eval_tidy(x$call$pmethod) == "backward"
@@ -91,6 +93,8 @@ test_that('check model reduction', {
 
 test_that('check MARS parsnip interface', {
   skip_if_not_installed("earth")
+  skip_if_not_installed("modeldata")
+
   set.seed(4779)
   expect_error(
     reg_mod <- bag_mars(num_terms = 5, prod_degree = 2) %>%

--- a/tests/testthat/test-nnet.R
+++ b/tests/testthat/test-nnet.R
@@ -1,6 +1,8 @@
 
 test_that('check nnet parsnip interface', {
   skip_if_not_installed("nnet")
+  skip_if_not_installed("modeldata")
+
   data(two_class_dat, package = "modeldata")
 
   set.seed(4779)

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -88,6 +88,8 @@ test_that('validate imps', {
 
 test_that('bad inputs', {
   skip_if_not_installed("earth")
+  skip_if_not_installed("modeldata")
+
   expect_error(
     bagger(mpg ~ ., data = mtcars, base_model = letters[1:2]),
     "should be a single character value."


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.